### PR TITLE
Add GitHub Actions test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Configuration validity check\
+on:
+- push
+jobs:
+  validate-json:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run validation script
+      run: ./validate_json.sh
+  validate-deployment-configs:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run metadata config check script
+      run: ./validate_deployments.sh
+

--- a/README.md
+++ b/README.md
@@ -12,4 +12,9 @@ Because invalid JSON files can cause the IOOS Glider DAC to break, it's worth do
 
 If all is good you should see `All JSON files are valid.`. Otherwise, you'll see a list of bad files to fix.
 
+You can additionally run `./validate_deployments.sh` to perform a set of
+sanity checks that go beyond just checking the validity of the JSON formatting.
+
+Both scripts also run via GitHub Actions when you push changes.
+
 For reference please see https://github.com/ioos/ioosngdac/wiki/NGDAC-NetCDF-File-Format-Version-2.

--- a/validate_deployments.sh
+++ b/validate_deployments.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+DIR="${1:-$(pwd)}"
+valid=1
+
+for json_file in $(find "$DIR" -type f -name "deployment.json"); do
+    if [[ $json_file =~ "template-YYYYMMDDTHHII" ]]; then
+        continue
+    fi
+    # Check that the deployment directory name matches the
+    # attributes set in deployment json
+    deployment_dir_name=$(basename $(dirname $json_file))
+    deployment_name=$(jq -r '"\(.glider)-\(.trajectory_date)"' $json_file)
+    if (( $? )); then
+        echo "Failed to read $json_file"
+        valid=0
+        continue
+    fi
+
+    if [[ $deployment_dir_name != $deployment_name ]]; then
+        echo "Invalid deployment config: $json_file"
+        echo "Directory name does not match '$deployment_name' (based on the 'glider' and 'trajectory_date' attributes)."
+        valid=0
+    fi
+done
+
+if (( $valid )); then
+  echo "All deployment JSON files passed."
+  exit 0
+fi
+
+exit 1
+

--- a/validate_json.sh
+++ b/validate_json.sh
@@ -12,5 +12,8 @@ done
 
 if [ "$valid" = true ]; then
     echo "All JSON files are valid."
+    exit 0
 fi
+
+exit 1
 


### PR DESCRIPTION
- Add an extra "validate" script that compares every config directory name with the `glider` and `trajectory_date` deployment attributes
  - more checks like this could be added to the script in the future
  - this is to catch early any mistakes, like d00383a0b92ed76add652c2ff4107bc6a1177600, which can be difficult to rectify if the glider is ingested with incorrect metadata
- Add a workflow that runs the available validation/check scripts on every push for every branch

After pushing breaking test commits:
![image](https://github.com/user-attachments/assets/4ee71941-298a-4bdc-bceb-4dea421a21ce)
![image](https://github.com/user-attachments/assets/66fca2df-d0c9-403b-beea-a4c8908c1921)
The test commits were removed via a force-push so the workflow should be passing again.

You can see the workflow runs in the history:
- https://github.com/honzaflash/SGS/actions/runs/16181522442
- https://github.com/honzaflash/SGS/actions/runs/16181751551